### PR TITLE
fix(resource):resource now show unit type correctly in database

### DIFF
--- a/backend/Migrations/20260603142105_AddUnitTypeForResources.Designer.cs
+++ b/backend/Migrations/20260603142105_AddUnitTypeForResources.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.data;
@@ -11,9 +12,11 @@ using backend.data;
 namespace backend.Migrations
 {
     [DbContext(typeof(MaintenanceDbContext))]
-    partial class MaintenanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603142105_AddUnitTypeForResources")]
+    partial class AddUnitTypeForResources
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260603142105_AddUnitTypeForResources.cs
+++ b/backend/Migrations/20260603142105_AddUnitTypeForResources.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnitTypeForResources : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Unit",
+                table: "Resources",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Unit",
+                table: "Resources");
+        }
+    }
+}

--- a/backend/SeedData.cs
+++ b/backend/SeedData.cs
@@ -34,23 +34,17 @@ namespace backend
             var fakeFuel = new Faker<Fuel>()
                 .RuleFor(f => f.Sku, f => $"FUEL-{f.Random.Int(0, 100000)}")
                 .RuleFor(f => f.Name, f => f.Commerce.ProductName())
-                .RuleFor(f => f.Amount, f => f.Random.Int(100, 5000))
-                .RuleFor(f => f.Type, _ => ResourceType.Fuel)
-                .RuleFor(f => f.Unit, _ => UnitType.L);
+                .RuleFor(f => f.Amount, f => f.Random.Int(100, 5000));
 
             var fakeAmmo = new Faker<Ammunition>()
                 .RuleFor(a => a.Sku, f => $"AMMO-{f.Random.Int(0, 100000)}")
                 .RuleFor(a => a.Name, f => f.Commerce.ProductName())
-                .RuleFor(a => a.Amount, f => f.Random.Int(100, 2000))
-                .RuleFor(a => a.Type, _ => ResourceType.Ammunition)
-                .RuleFor(a => a.Unit, _ => UnitType.rounds);
+                .RuleFor(a => a.Amount, f => f.Random.Int(100, 2000));
 
             var fakeBattery = new Faker<Battery>()
                 .RuleFor(b => b.Sku, f => $"BAT-{f.Random.Int(0, 100000)}")
                 .RuleFor(b => b.Name, f => f.Commerce.ProductName())
-                .RuleFor(b => b.Amount, f => f.Random.Int(1, 10))
-                .RuleFor(b => b.Type, _ => ResourceType.Battery)
-                .RuleFor(b => b.Unit, _ => UnitType.kWh);
+                .RuleFor(b => b.Amount, f => f.Random.Int(1, 10));
 
             var fakeSite = new Faker<MaintenanceSite>();
 

--- a/backend/data/MaintenanceDbContext.cs
+++ b/backend/data/MaintenanceDbContext.cs
@@ -1,4 +1,5 @@
 using backend.types;
+using backend.utils;
 using Microsoft.EntityFrameworkCore;
 
 namespace backend.data
@@ -15,17 +16,21 @@ namespace backend.data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Personnel>()
-            .HasDiscriminator<UserRole>("Role")
-            .HasValue<Technician>(UserRole.Technician)
-            .HasValue<Operator>(UserRole.Operator)
-            .HasValue<Supervisor>(UserRole.Supervisor);
+            List<Personnel> personnel = [
+                new Technician(),
+                new Operator(),
+                new Supervisor()
+            ];
 
-            modelBuilder.Entity<ResourceGeneric>()
-            .HasDiscriminator<ResourceType>("Type")
-            .HasValue<Fuel>(ResourceType.Fuel)
-            .HasValue<Ammunition>(ResourceType.Ammunition)
-            .HasValue<Battery>(ResourceType.Battery);
+            modelBuilder.AutoMapByEnum<Personnel, UserRole>("Role", personnel);
+
+            List<ResourceGeneric> resources = [
+                new Fuel(),
+                new Ammunition(),
+                new Battery()
+            ];
+
+            modelBuilder.AutoMapByEnum<ResourceGeneric, ResourceType>("Type", resources);
 
             modelBuilder.Entity<ResourceGeneric>()
             .HasOne(r => r.Airplane)

--- a/backend/types/Resource.cs
+++ b/backend/types/Resource.cs
@@ -9,7 +9,7 @@ namespace backend.types
 
         public int Amount { get; set; }
 
-        public virtual UnitType Unit { get; }
+        public abstract UnitType Unit { get; set; }
         public virtual ResourceType Type { get; }
 
         public int? AirplaneId { get; set; }
@@ -33,19 +33,19 @@ namespace backend.types
     public class Fuel : ResourceGeneric
     {
         public override ResourceType Type => ResourceType.Fuel;
-        public override UnitType Unit => UnitType.L;
+        public override UnitType Unit { get; set; } = UnitType.L;
     }
 
     public class Ammunition : ResourceGeneric
     {
         public override ResourceType Type => ResourceType.Ammunition;
-        public override UnitType Unit => UnitType.rounds;
+        public override UnitType Unit { get; set; } = UnitType.rounds;
     }
 
     public class Battery : ResourceGeneric
     {
         public override ResourceType Type => ResourceType.Battery;
-        public override UnitType Unit => UnitType.kWh;
+        public override UnitType Unit { get; set; } = UnitType.kWh;
     }
 
     public class ResourceBuffer

--- a/backend/utils/ModelBuilderExtensions.cs
+++ b/backend/utils/ModelBuilderExtensions.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace backend.utils
+{
+    public static class ModelBuilderExtensions
+    {
+        // TBase = your base class (ResourceGeneric)
+        // TEnum = your enum type (UnitType)
+        public static void AutoMapByEnum<TBase, TEnum>(
+            this ModelBuilder modelBuilder,
+            string dbColumnName,
+            List<TBase> instances
+        ) where TBase : class where TEnum : Enum
+        {
+            // 1. Tell EF Core what the column name is in the database
+            var discriminator = modelBuilder.Entity<TBase>().HasDiscriminator<TEnum>(dbColumnName);
+
+            // 2. Loop through your instances
+            foreach (var instance in instances)
+            {
+                Type type = instance.GetType();
+
+                // 3. Find the property inside the class that matches the Enum type
+                var enumProperty = type.GetProperties()
+                    .FirstOrDefault(p => p.PropertyType == typeof(TEnum));
+
+                if (enumProperty != null)
+                {
+                    // 4. Extract the enum value (e.g., UnitType.L)
+                    var enumValue = (TEnum)enumProperty.GetValue(instance)!;
+
+                    // 5. Register it with EF Core
+                    discriminator.HasValue(type, enumValue);
+                }
+            }
+        }
+
+        public static void AutoMapDerivedTypes<TBase, TDiscriminator>(
+        this ModelBuilder modelBuilder,
+        string columnName,
+        List<TBase> instances) where TBase : class
+        {
+            // 1. Setup the discriminator on EF Core dynamically
+            var discriminator = modelBuilder.Entity<TBase>().HasDiscriminator<TDiscriminator>(columnName);
+
+            // 2. Loop through whatever list of instances you passed in
+            foreach (var instance in instances)
+            {
+                Type type = instance.GetType();
+
+                // 3. Use Reflection safely to grab the value of the property matching your column name
+                var propertyInfo = type.GetProperty(columnName);
+                if (propertyInfo != null)
+                {
+                    var value = (TDiscriminator)propertyInfo.GetValue(instance)!;
+                    discriminator.HasValue(type, value);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Can only have one discriminator in a TPH(Table-Per-Hierarchy).
- Solution was to change to `public abstract UnitType Unit { get; set; }`.
- This PR also includes a helper function to map `Enum` or properties as discriminators for the modelbuilder. Reduces duplicate code.

Fixed #52 