### PR TITLE
fix(personnel):flatten personnel data model

### DIFF
--- a/backend/Migrations/20260609134214_FlattenPersonnelModel.Designer.cs
+++ b/backend/Migrations/20260609134214_FlattenPersonnelModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.data;
@@ -11,9 +12,11 @@ using backend.data;
 namespace backend.Migrations
 {
     [DbContext(typeof(MaintenanceDbContext))]
-    partial class MaintenanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609134214_FlattenPersonnelModel")]
+    partial class FlattenPersonnelModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260609134214_FlattenPersonnelModel.cs
+++ b/backend/Migrations/20260609134214_FlattenPersonnelModel.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class FlattenPersonnelModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Personnel_Tasks_MaintenanceTaskId",
+                table: "Personnel");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Personnel_Tasks_Technician_CurrentTaskId",
+                table: "Personnel");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Personnel_MaintenanceTaskId",
+                table: "Personnel");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Personnel_Technician_CurrentTaskId",
+                table: "Personnel");
+
+            migrationBuilder.DropColumn(
+                name: "MaintenanceTaskId",
+                table: "Personnel");
+
+            migrationBuilder.DropColumn(
+                name: "Technician_CurrentTaskId",
+                table: "Personnel");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaintenanceTaskId",
+                table: "Personnel",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Technician_CurrentTaskId",
+                table: "Personnel",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Personnel_MaintenanceTaskId",
+                table: "Personnel",
+                column: "MaintenanceTaskId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Personnel_Technician_CurrentTaskId",
+                table: "Personnel",
+                column: "Technician_CurrentTaskId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Personnel_Tasks_MaintenanceTaskId",
+                table: "Personnel",
+                column: "MaintenanceTaskId",
+                principalTable: "Tasks",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Personnel_Tasks_Technician_CurrentTaskId",
+                table: "Personnel",
+                column: "Technician_CurrentTaskId",
+                principalTable: "Tasks",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/backend/PersonnelItems/PersonnelService.cs
+++ b/backend/PersonnelItems/PersonnelService.cs
@@ -63,7 +63,7 @@ namespace backend.PersonnelItems
         public async Task<bool> AssignTaskAsync(int id, int? taskId)
         {
             Personnel? worker = await _db.Personnel
-                .Where(p => p.Id == id && (p is Technician || p is Supervisor))
+                .Where(p => p.Id == id && (p.Role == UserRole.Technician || p.Role == UserRole.Supervisor))
                 .FirstOrDefaultAsync();
 
             if (worker is null)
@@ -79,13 +79,14 @@ namespace backend.PersonnelItems
                 }
             }
 
-            if (worker is Technician tech)
+            switch (worker.Role)
             {
-                tech.CurrentTaskId = taskId;
-            }
-            else if (worker is Supervisor super)
-            {
-                super.CurrentTaskId = taskId;
+                case UserRole.Technician:
+                    worker.CurrentTaskId = taskId;
+                    break;
+                case UserRole.Supervisor:
+                    worker.CurrentTaskId = taskId;
+                    break;
             }
 
             await _db.SaveChangesAsync();
@@ -94,9 +95,9 @@ namespace backend.PersonnelItems
 
         public async Task<bool> AssignOrderAsync(int id, int? orderId)
         {
-            Operator? op = await _db.Personnel
-                .OfType<Operator>()
-                .FirstOrDefaultAsync(p => p.Id == id);
+            Personnel? op = await _db.Personnel
+                .OfType<Personnel>()
+                .FirstOrDefaultAsync(p => p.Id == id && p.Role == UserRole.Operator);
 
             if (op is null)
             {

--- a/backend/SeedData.cs
+++ b/backend/SeedData.cs
@@ -16,17 +16,17 @@ namespace backend
 
             if (await context.Airplanes.AnyAsync()) return;
 
-            var fakeTech = new Faker<Technician>()
+            var fakeTech = new Faker<Personnel>()
                 .RuleFor(t => t.Name, f => f.Person.FirstName + " " + f.Person.LastName)
                 .RuleFor(t => t.Status, _ => PersonnelStatus.Inactive)
                 .RuleFor(t => t.Role, _ => UserRole.Technician);
 
-            var fakeOperator = new Faker<Operator>()
+            var fakeOperator = new Faker<Personnel>()
                 .RuleFor(o => o.Name, f => f.Person.FirstName + " " + f.Person.LastName)
                 .RuleFor(o => o.Status, _ => PersonnelStatus.Inactive)
                 .RuleFor(o => o.Role, _ => UserRole.Operator);
 
-            var fakeSupervisor = new Faker<Supervisor>()
+            var fakeSupervisor = new Faker<Personnel>()
                 .RuleFor(s => s.Name, f => f.Person.FirstName + " " + f.Person.LastName)
                 .RuleFor(s => s.Status, _ => PersonnelStatus.Inactive)
                 .RuleFor(s => s.Role, _ => UserRole.Supervisor);

--- a/backend/TaskItems/TaskService.cs
+++ b/backend/TaskItems/TaskService.cs
@@ -11,7 +11,7 @@ namespace backend.TaskItems
 
         public async Task<List<MaintenanceTaskDTO>> GetAllAsync()
         {
-            List<MaintenanceTask> tasks = await _db.Tasks.ToListAsync();
+            List<MaintenanceTask> tasks = await _db.Tasks.Include(t => t.AssignedPersonnel).ToListAsync();
             List<MaintenanceTaskDTO> dTOs = [.. tasks.Select(MaintenanceTaskDTO.FromEntity)];
 
             return dTOs;

--- a/backend/data/MaintenanceDbContext.cs
+++ b/backend/data/MaintenanceDbContext.cs
@@ -16,14 +16,6 @@ namespace backend.data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            List<Personnel> personnel = [
-                new Technician(),
-                new Operator(),
-                new Supervisor()
-            ];
-
-            modelBuilder.AutoMapByEnum<Personnel, UserRole>("Role", personnel);
-
             List<ResourceGeneric> resources = [
                 new Fuel(),
                 new Ammunition(),

--- a/backend/types/DTO/MaintenanceDTO.cs
+++ b/backend/types/DTO/MaintenanceDTO.cs
@@ -99,7 +99,8 @@ namespace backend.types.DTO
         int MaintenanceOrderId,
         int AirplaneId,
         TaskType Type,
-        double DurationMinutes
+        double DurationMinutes,
+        IReadOnlyList<int> AssignedPersonnel
     ) : MaintenanceGenericDTO(
         Id,
         Comments,
@@ -123,7 +124,8 @@ namespace backend.types.DTO
             MaintenanceOrderId: task.MaintenanceOrderId,
             AirplaneId: task.AirplaneId,
             Type: task.Type,
-            DurationMinutes: task.Duration.TotalMinutes
+            DurationMinutes: task.Duration.TotalMinutes,
+            AssignedPersonnel: [.. task.AssignedPersonnel.Select(p => p.Id)]
         );
 
         public static MaintenanceTask FromDTO(CreateMaintenanceTaskDTO dto)

--- a/backend/types/DTO/PersonnelDTO.cs
+++ b/backend/types/DTO/PersonnelDTO.cs
@@ -21,20 +21,20 @@ namespace backend.types.DTO
 
         public static PersonnelDTO MapToDto(Personnel personnel) => personnel switch
         {
-            Technician t => new PersonnelDTO(t.Id, t.Name, t.Status, t.Role, t.CurrentTaskId),
-            Supervisor s => new PersonnelDTO(s.Id, s.Name, s.Status, s.Role, s.CurrentTaskId),
-            Operator o => new PersonnelDTO(o.Id, o.Name, o.Status, o.Role, CurrentOrderId: o.CurrentOrderId),
+            { Role: UserRole.Technician } t => new PersonnelDTO(t.Id, t.Name, t.Status, t.Role, t.CurrentTaskId),
+            { Role: UserRole.Supervisor } s => new PersonnelDTO(s.Id, s.Name, s.Status, s.Role, s.CurrentTaskId),
+            { Role: UserRole.Operator } o => new PersonnelDTO(o.Id, o.Name, o.Status, o.Role, CurrentOrderId: o.CurrentOrderId),
             _ => throw new ArgumentException("Unknown personnel type")
         };
 
         public static Personnel MapFromDto(CreatePersonnelDTO personnel) => personnel.Role switch
         {
-            UserRole.Technician => new Technician
-            { Name = personnel.Name, },
-            UserRole.Supervisor => new Supervisor
-            { Name = personnel.Name, },
-            UserRole.Operator => new Operator
-            { Name = personnel.Name, },
+            UserRole.Technician => new Personnel
+            { Name = personnel.Name, Role = UserRole.Technician },
+            UserRole.Supervisor => new Personnel
+            { Name = personnel.Name, Role = UserRole.Supervisor },
+            UserRole.Operator => new Personnel
+            { Name = personnel.Name, Role = UserRole.Operator },
             _ => throw new ArgumentException($"Unknown personnel role: {personnel.Role}")
         };
     }

--- a/backend/types/Personnel.cs
+++ b/backend/types/Personnel.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
 namespace backend.types
 {
-    public abstract class Personnel
+    public class Personnel
     {
         public int Id { get; set; }
 
@@ -8,35 +11,17 @@ namespace backend.types
 
         public PersonnelStatus Status { get; set; } = PersonnelStatus.Inactive;
 
-        public abstract UserRole Role { get; set; }
-
-    }
-
-    public class Technician : Personnel
-    {
-        public override UserRole Role { get; set; } = UserRole.Technician;
+        public UserRole Role { get; set; }
 
         public int? CurrentTaskId { get; set; }
 
+        [ForeignKey(nameof(CurrentTaskId))]
         public MaintenanceTask? CurrentTask { get; set; }
-    }
-
-    public class Operator : Personnel
-    {
-        public override UserRole Role { get; set; } = UserRole.Operator;
 
         public int? CurrentOrderId { get; set; }
 
+        [ForeignKey(nameof(CurrentOrderId))]
         public MaintenanceOrder? CurrentOrder { get; set; }
-    }
-
-    public class Supervisor : Personnel
-    {
-        public override UserRole Role { get; set; } = UserRole.Supervisor;
-
-        public int? CurrentTaskId { get; set; }
-
-        public MaintenanceTask? CurrentTask { get; set; }
     }
 
     public enum UserRole

--- a/backend/types/Personnel.cs
+++ b/backend/types/Personnel.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
 
 namespace backend.types
 {


### PR DESCRIPTION
- Added `AssignedPersonnel` in `MaintenanceTaskDTO` when fetching tasks. Fixed #78 
- Instead of different classes representing the roles there is a `Personnel` class with `CurrentTask` and `CurrentOrder`. It's possible to separate the class later on if needed.

Fixed #77 