### PR TITLE
Fix/defaultdatetimeoffset

### DIFF
--- a/backend/Migrations/20260611095145_AddDefaultValueForCreatedAt.Designer.cs
+++ b/backend/Migrations/20260611095145_AddDefaultValueForCreatedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.data;
@@ -11,9 +12,11 @@ using backend.data;
 namespace backend.Migrations
 {
     [DbContext(typeof(MaintenanceDbContext))]
-    partial class MaintenanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611095145_AddDefaultValueForCreatedAt")]
+    partial class AddDefaultValueForCreatedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -47,7 +50,7 @@ namespace backend.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("CreatedAt")
+                    b.Property<DateTimeOffset>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NOW()");
@@ -56,20 +59,20 @@ namespace backend.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("EndedAt")
+                    b.Property<DateTimeOffset>("EndedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("OrderTitle")
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("StartedAt")
+                    b.Property<DateTimeOffset>("StartedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 
-                    b.Property<DateTimeOffset?>("UpdatedAt")
+                    b.Property<DateTimeOffset>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
@@ -113,7 +116,7 @@ namespace backend.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<DateTimeOffset?>("CreatedAt")
+                    b.Property<DateTimeOffset>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NOW()");
@@ -128,13 +131,13 @@ namespace backend.Migrations
                     b.Property<TimeSpan>("Duration")
                         .HasColumnType("interval");
 
-                    b.Property<DateTimeOffset?>("EndedAt")
+                    b.Property<DateTimeOffset>("EndedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("MaintenanceOrderId")
                         .HasColumnType("integer");
 
-                    b.Property<DateTimeOffset?>("StartedAt")
+                    b.Property<DateTimeOffset>("StartedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Status")
@@ -143,7 +146,7 @@ namespace backend.Migrations
                     b.Property<int>("Type")
                         .HasColumnType("integer");
 
-                    b.Property<DateTimeOffset?>("UpdatedAt")
+                    b.Property<DateTimeOffset>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");

--- a/backend/Migrations/20260611095145_AddDefaultValueForCreatedAt.cs
+++ b/backend/Migrations/20260611095145_AddDefaultValueForCreatedAt.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultValueForCreatedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "NOW()");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "NOW()");
+        }
+    }
+}

--- a/backend/Migrations/20260611110446_AssignDateTimeOnUpdateAndCreate.Designer.cs
+++ b/backend/Migrations/20260611110446_AssignDateTimeOnUpdateAndCreate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using backend.data;
@@ -11,9 +12,11 @@ using backend.data;
 namespace backend.Migrations
 {
     [DbContext(typeof(MaintenanceDbContext))]
-    partial class MaintenanceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611110446_AssignDateTimeOnUpdateAndCreate")]
+    partial class AssignDateTimeOnUpdateAndCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260611110446_AssignDateTimeOnUpdateAndCreate.cs
+++ b/backend/Migrations/20260611110446_AssignDateTimeOnUpdateAndCreate.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AssignDateTimeOnUpdateAndCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "StartedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "EndedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: true,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "NOW()");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "StartedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "EndedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: true,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "NOW()");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "StartedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "EndedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true,
+                oldDefaultValueSql: "NOW()");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "StartedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "EndedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Orders",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "NOW()",
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true,
+                oldDefaultValueSql: "NOW()");
+        }
+    }
+}

--- a/backend/SeedData.cs
+++ b/backend/SeedData.cs
@@ -56,17 +56,13 @@ namespace backend
                 .RuleFor(o => o.Status, f => f.PickRandom<MaintenanceGenericStatus>())
                 .RuleFor(o => o.Description, f => f.Lorem.Sentence())
                 .RuleFor(t => t.Comments, f => f.Lorem.Sentence())
-                .RuleFor(o => o.StartedAt, f => f.Date.Soon().ToUniversalTime())
-                .RuleFor(o => o.CreatedAt, f => f.Date.Past().ToUniversalTime())
-                .RuleFor(o => o.UpdatedAt, f => f.Date.Recent().ToUniversalTime());
+                .RuleFor(o => o.StartedAt, f => f.Date.Soon().ToUniversalTime());
 
             var fakeTask = new Faker<MaintenanceTask>()
                 .RuleFor(t => t.Status, f => f.PickRandom<MaintenanceGenericStatus>())
                 .RuleFor(t => t.Description, f => f.Lorem.Sentence())
                 .RuleFor(t => t.Comments, f => f.Lorem.Sentence())
                 .RuleFor(t => t.StartedAt, f => f.Date.Soon().ToUniversalTime())
-                .RuleFor(t => t.CreatedAt, f => f.Date.Past().ToUniversalTime())
-                .RuleFor(t => t.UpdatedAt, f => f.Date.Recent().ToUniversalTime())
                 .RuleFor(t => t.Type, f => f.PickRandom<TaskType>())
                 .RuleFor(t => t.Duration, f => f.Date.Timespan())
                 .RuleFor(t => t.Deadline, f => f.Date.Future().ToUniversalTime());

--- a/backend/data/MaintenanceDbContext.cs
+++ b/backend/data/MaintenanceDbContext.cs
@@ -1,10 +1,18 @@
 using backend.types;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace backend.data
 {
     public class MaintenanceDbContext(DbContextOptions<MaintenanceDbContext> options) : DbContext(options)
     {
+
+        public MaintenanceDbContext() : this(new DbContextOptions<MaintenanceDbContext>())
+        {
+            ChangeTracker.StateChanged += UpdateTimestamps;
+            ChangeTracker.Tracked += UpdateTimestamps;
+        }
+
         public DbSet<Airplane> Airplanes => Set<Airplane>();
         public DbSet<MaintenanceSite> Sites => Set<MaintenanceSite>();
         public DbSet<MaintenanceOrder> Orders => Set<MaintenanceOrder>();
@@ -12,6 +20,22 @@ namespace backend.data
         public DbSet<Personnel> Personnel => Set<Personnel>();
         public DbSet<Resource> Resources => Set<Resource>();
         public DbSet<TaskResourceRequirement> ResourceRequirements => Set<TaskResourceRequirement>();
+
+        private static void UpdateTimestamps(object? sender, EntityEntryEventArgs e)
+        {
+            if (e.Entry.Entity is IHasTimestamps entityWithTimestamps)
+            {
+                switch (e.Entry.State)
+                {
+                    case EntityState.Modified:
+                        entityWithTimestamps.UpdatedAt = DateTime.UtcNow;
+                        break;
+                    case EntityState.Added:
+                        entityWithTimestamps.CreatedAt = DateTime.UtcNow;
+                        break;
+                }
+            }
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -22,6 +46,14 @@ namespace backend.data
             modelBuilder.Entity<Resource>()
             .HasIndex(r => r.Sku)
             .IsUnique();
+
+            modelBuilder.Entity<MaintenanceOrder>()
+            .Property(b => b.CreatedAt)
+            .HasDefaultValueSql("NOW()");
+
+            modelBuilder.Entity<MaintenanceTask>()
+            .Property(b => b.CreatedAt)
+            .HasDefaultValueSql("NOW()");
         }
     }
 }

--- a/backend/types/DTO/MaintenanceDTO.cs
+++ b/backend/types/DTO/MaintenanceDTO.cs
@@ -9,10 +9,10 @@ namespace backend.types.DTO
         string Comments,
         string Description,
         MaintenanceGenericStatus Status,
-        DateTimeOffset StartedAt,
-        DateTimeOffset CreatedAt,
-        DateTimeOffset UpdatedAt,
-        DateTimeOffset EndedAt
+        DateTimeOffset? StartedAt = null,
+        DateTimeOffset? CreatedAt = null,
+        DateTimeOffset? UpdatedAt = null,
+        DateTimeOffset? EndedAt = null
     );
 
     public record MaintenanceOrderDTO(
@@ -21,10 +21,10 @@ namespace backend.types.DTO
         string Comments,
         string Description,
         MaintenanceGenericStatus Status,
-        DateTimeOffset StartedAt,
-        DateTimeOffset CreatedAt,
-        DateTimeOffset UpdatedAt,
-        DateTimeOffset EndedAt,
+        DateTimeOffset? StartedAt,
+        DateTimeOffset? CreatedAt,
+        DateTimeOffset? UpdatedAt,
+        DateTimeOffset? EndedAt,
 
         //Unique fields
         string OrderTitle
@@ -68,7 +68,6 @@ namespace backend.types.DTO
         string? Description,
         MaintenanceGenericStatus? Status,
         DateTimeOffset? StartedAt,
-        DateTimeOffset? UpdatedAt,
         DateTimeOffset? EndedAt,
 
         //Unique fields
@@ -90,10 +89,10 @@ namespace backend.types.DTO
         string Comments,
         string Description,
         MaintenanceGenericStatus Status,
-        DateTimeOffset StartedAt,
-        DateTimeOffset CreatedAt,
-        DateTimeOffset UpdatedAt,
-        DateTimeOffset EndedAt,
+        DateTimeOffset? StartedAt,
+        DateTimeOffset? CreatedAt,
+        DateTimeOffset? UpdatedAt,
+        DateTimeOffset? EndedAt,
 
         //Unique fields
         int MaintenanceOrderId,
@@ -147,7 +146,6 @@ namespace backend.types.DTO
         string? Description,
         MaintenanceGenericStatus? Status,
         DateTimeOffset? StartedAt,
-        DateTimeOffset? UpdatedAt,
         DateTimeOffset? EndedAt,
 
         //Unique fields

--- a/backend/types/Maintenance.cs
+++ b/backend/types/Maintenance.cs
@@ -10,6 +10,14 @@ namespace backend.types
         public MaintenanceTask? CurrentTask { get; set; }
     }
 
+    public interface IHasTimestamps
+    {
+        public DateTimeOffset? StartedAt { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
+        public DateTimeOffset? UpdatedAt { get; set; }
+        public DateTimeOffset? EndedAt { get; set; }
+    }
+
     public abstract class MaintenanceGeneric
     {
         public int Id { get; set; }
@@ -17,11 +25,10 @@ namespace backend.types
         public string Description { get; set; } = "";
 
         public MaintenanceGenericStatus Status { get; set; }
-
-        public DateTimeOffset StartedAt { get; set; }
-        public DateTimeOffset CreatedAt { get; set; }
-        public DateTimeOffset UpdatedAt { get; set; }
-        public DateTimeOffset EndedAt { get; set; }
+        public DateTimeOffset? StartedAt { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset? UpdatedAt { get; set; }
+        public DateTimeOffset? EndedAt { get; set; }
     }
 
     public class MaintenanceOrder : MaintenanceGeneric


### PR DESCRIPTION
- `CreatedAt` and `UpdatedAt` not required in DTO since it updates when the object is modified or added into the database. 
- Only `EndedAt` and `StartedAt` is specified from the client.

Fixed #66 